### PR TITLE
Add disable_shutdown option to Hyper-V builders.

### DIFF
--- a/builder/hyperv/common/step_shutdown.go
+++ b/builder/hyperv/common/step_shutdown.go
@@ -24,8 +24,9 @@ import (
 // Produces:
 //   <nothing>
 type StepShutdown struct {
-	Command string
-	Timeout time.Duration
+	Command         string
+	Timeout         time.Duration
+	DisableShutdown bool
 }
 
 func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -35,54 +36,58 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 	ui := state.Get("ui").(packersdk.Ui)
 	vmName := state.Get("vmName").(string)
 
-	if s.Command != "" {
-		ui.Say("Gracefully halting virtual machine...")
-		log.Printf("Executing shutdown command: %s", s.Command)
+	if !s.DisableShutdown {
+		if s.Command != "" {
+			ui.Say("Gracefully halting virtual machine...")
+			log.Printf("Executing shutdown command: %s", s.Command)
 
-		var stdout, stderr bytes.Buffer
-		cmd := &packersdk.RemoteCmd{
-			Command: s.Command,
-			Stdout:  &stdout,
-			Stderr:  &stderr,
-		}
-		if err := comm.Start(ctx, cmd); err != nil {
-			err := fmt.Errorf("Failed to send shutdown command: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-
-		// Wait for the machine to actually shut down
-		log.Printf("Waiting max %s for shutdown to complete", s.Timeout)
-		shutdownTimer := time.After(s.Timeout)
-		for {
-			running, _ := driver.IsRunning(vmName)
-			if !running {
-				break
+			var stdout, stderr bytes.Buffer
+			cmd := &packersdk.RemoteCmd{
+				Command: s.Command,
+				Stdout:  &stdout,
+				Stderr:  &stderr,
 			}
-
-			select {
-			case <-shutdownTimer:
-				log.Printf("Shutdown stdout: %s", stdout.String())
-				log.Printf("Shutdown stderr: %s", stderr.String())
-				err := errors.New("Timeout while waiting for machine to shut down.")
+			if err := comm.Start(ctx, cmd); err != nil {
+				err := fmt.Errorf("Failed to send shutdown command: %s", err)
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
-			default:
-				time.Sleep(500 * time.Millisecond)
+			}
+
+		} else {
+			ui.Say("Forcibly halting virtual machine...")
+			if err := driver.Stop(vmName); err != nil {
+				err := fmt.Errorf("Error stopping VM: %s", err)
+				state.Put("error", err)
+				ui.Error(err.Error())
+				return multistep.ActionHalt
 			}
 		}
 	} else {
-		ui.Say("Forcibly halting virtual machine...")
-		if err := driver.Stop(vmName); err != nil {
-			err := fmt.Errorf("Error stopping VM: %s", err)
+		ui.Say("Automatic shutdown disabled.")
+	}
+
+	// Wait for the machine to actually shut down
+	log.Printf("Waiting max %s for shutdown to complete", s.Timeout)
+	shutdownTimer := time.After(s.Timeout)
+	for {
+		running, _ := driver.IsRunning(vmName)
+		if !running {
+			break
+		}
+
+		select {
+		case <-shutdownTimer:
+			//log.Printf("Shutdown stdout: %s", stdout.String())
+			//log.Printf("Shutdown stderr: %s", stderr.String())
+			err := errors.New("Timeout while waiting for machine to shut down.")
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
+		default:
+			time.Sleep(500 * time.Millisecond)
 		}
 	}
-
 	log.Println("VM shut down.")
 	return multistep.ActionContinue
 }

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -61,7 +61,12 @@ type Config struct {
 	hypervcommon.SSHConfig         `mapstructure:",squash"`
 	hypervcommon.CommonConfig      `mapstructure:",squash"`
 	shutdowncommand.ShutdownConfig `mapstructure:",squash"`
-	// Disable automatic shut down of the virtual machine.
+	// Packer normally halts the virtual machine after all provisioners have
+	// run when no `shutdown_command` is defined. If this is set to `true`, Packer
+	// *will not* halt the virtual machine but will assume that the VM will shut itself down
+	// when it's done, via the preseed.cfg or your final provisioner.
+	// Packer will wait for a default of 5 minutes until the virtual machine is shutdown.
+	// The timeout can be changed using the `shutdown_timeout` option.
 	DisableShutdown bool `mapstructure:"disable_shutdown" required:"false"`
 	// The size, in megabytes, of the hard disk to create
 	// for the VM. By default, this is 40 GB.

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -61,6 +61,8 @@ type Config struct {
 	hypervcommon.SSHConfig         `mapstructure:",squash"`
 	hypervcommon.CommonConfig      `mapstructure:",squash"`
 	shutdowncommand.ShutdownConfig `mapstructure:",squash"`
+	// Disable automatic shut down of the virtual machine.
+	DisableShutdown bool `mapstructure:"disable_shutdown" required:"false"`
 	// The size, in megabytes, of the hard disk to create
 	// for the VM. By default, this is 40 GB.
 	DiskSize uint `mapstructure:"disk_size" required:"false"`
@@ -302,8 +304,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 
 		&hypervcommon.StepShutdown{
-			Command: b.config.ShutdownCommand,
-			Timeout: b.config.ShutdownTimeout,
+			Command:         b.config.ShutdownCommand,
+			Timeout:         b.config.ShutdownTimeout,
+			DisableShutdown: b.config.DisableShutdown,
 		},
 
 		// wait for the vm to be powered off

--- a/builder/hyperv/iso/builder.hcl2spec.go
+++ b/builder/hyperv/iso/builder.hcl2spec.go
@@ -115,6 +115,7 @@ type FlatConfig struct {
 	BootOrder                      []string          `mapstructure:"boot_order" required:"false" cty:"boot_order" hcl:"boot_order"`
 	ShutdownCommand                *string           `mapstructure:"shutdown_command" required:"false" cty:"shutdown_command" hcl:"shutdown_command"`
 	ShutdownTimeout                *string           `mapstructure:"shutdown_timeout" required:"false" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
+	DisableShutdown                *bool             `mapstructure:"disable_shutdown" required:"false" cty:"disable_shutdown" hcl:"disable_shutdown"`
 	DiskSize                       *uint             `mapstructure:"disk_size" required:"false" cty:"disk_size" hcl:"disk_size"`
 	UseLegacyNetworkAdapter        *bool             `mapstructure:"use_legacy_network_adapter" required:"false" cty:"use_legacy_network_adapter" hcl:"use_legacy_network_adapter"`
 	DifferencingDisk               *bool             `mapstructure:"differencing_disk" required:"false" cty:"differencing_disk" hcl:"differencing_disk"`
@@ -238,6 +239,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_order":                       &hcldec.AttrSpec{Name: "boot_order", Type: cty.List(cty.String), Required: false},
 		"shutdown_command":                 &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout":                 &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
+		"disable_shutdown":                 &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
 		"disk_size":                        &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"use_legacy_network_adapter":       &hcldec.AttrSpec{Name: "use_legacy_network_adapter", Type: cty.Bool, Required: false},
 		"differencing_disk":                &hcldec.AttrSpec{Name: "differencing_disk", Type: cty.Bool, Required: false},

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -52,7 +52,12 @@ type Config struct {
 	hypervcommon.SSHConfig         `mapstructure:",squash"`
 	hypervcommon.CommonConfig      `mapstructure:",squash"`
 	shutdowncommand.ShutdownConfig `mapstructure:",squash"`
-	// Disable automatic shut down of the virtual machine.
+	// Packer normally halts the virtual machine after all provisioners have
+	// run when no `shutdown_command` is defined. If this is set to `true`, Packer
+	// *will not* halt the virtual machine but will assume that the VM will shut itself down
+	// when it's done, via the preseed.cfg or your final provisioner.
+	// Packer will wait for a default of 5 minutes until the virtual machine is shutdown.
+	// The timeout can be changed using the `shutdown_timeout` option.
 	DisableShutdown bool `mapstructure:"disable_shutdown" required:"false"`
 	// This is the path to a directory containing an exported virtual machine.
 	CloneFromVMCXPath string `mapstructure:"clone_from_vmcx_path"`

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -52,7 +52,8 @@ type Config struct {
 	hypervcommon.SSHConfig         `mapstructure:",squash"`
 	hypervcommon.CommonConfig      `mapstructure:",squash"`
 	shutdowncommand.ShutdownConfig `mapstructure:",squash"`
-
+	// Disable automatic shut down of the virtual machine.
+	DisableShutdown bool `mapstructure:"disable_shutdown" required:"false"`
 	// This is the path to a directory containing an exported virtual machine.
 	CloneFromVMCXPath string `mapstructure:"clone_from_vmcx_path"`
 	// This is the name of the virtual machine to clone from.
@@ -342,8 +343,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 
 		&hypervcommon.StepShutdown{
-			Command: b.config.ShutdownCommand,
-			Timeout: b.config.ShutdownTimeout,
+			Command:         b.config.ShutdownCommand,
+			Timeout:         b.config.ShutdownTimeout,
+			DisableShutdown: b.config.DisableShutdown,
 		},
 
 		// wait for the vm to be powered off

--- a/builder/hyperv/vmcx/builder.hcl2spec.go
+++ b/builder/hyperv/vmcx/builder.hcl2spec.go
@@ -115,6 +115,7 @@ type FlatConfig struct {
 	BootOrder                      []string          `mapstructure:"boot_order" required:"false" cty:"boot_order" hcl:"boot_order"`
 	ShutdownCommand                *string           `mapstructure:"shutdown_command" required:"false" cty:"shutdown_command" hcl:"shutdown_command"`
 	ShutdownTimeout                *string           `mapstructure:"shutdown_timeout" required:"false" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
+	DisableShutdown                *bool             `mapstructure:"disable_shutdown" required:"false" cty:"disable_shutdown" hcl:"disable_shutdown"`
 	CloneFromVMCXPath              *string           `mapstructure:"clone_from_vmcx_path" cty:"clone_from_vmcx_path" hcl:"clone_from_vmcx_path"`
 	CloneFromVMName                *string           `mapstructure:"clone_from_vm_name" cty:"clone_from_vm_name" hcl:"clone_from_vm_name"`
 	CloneFromSnapshotName          *string           `mapstructure:"clone_from_snapshot_name" required:"false" cty:"clone_from_snapshot_name" hcl:"clone_from_snapshot_name"`
@@ -240,6 +241,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_order":                       &hcldec.AttrSpec{Name: "boot_order", Type: cty.List(cty.String), Required: false},
 		"shutdown_command":                 &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout":                 &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
+		"disable_shutdown":                 &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
 		"clone_from_vmcx_path":             &hcldec.AttrSpec{Name: "clone_from_vmcx_path", Type: cty.String, Required: false},
 		"clone_from_vm_name":               &hcldec.AttrSpec{Name: "clone_from_vm_name", Type: cty.String, Required: false},
 		"clone_from_snapshot_name":         &hcldec.AttrSpec{Name: "clone_from_snapshot_name", Type: cty.String, Required: false},

--- a/docs-partials/builder/hyperv/iso/Config-not-required.mdx
+++ b/docs-partials/builder/hyperv/iso/Config-not-required.mdx
@@ -1,5 +1,12 @@
 <!-- Code generated from the comments of the Config struct in builder/hyperv/iso/builder.go; DO NOT EDIT MANUALLY -->
 
+- `disable_shutdown` (bool) - Packer normally halts the virtual machine after all provisioners have
+  run when no `shutdown_command` is defined. If this is set to `true`, Packer
+  *will not* halt the virtual machine but will assume that the VM will shut itself down
+  when it's done, via the preseed.cfg or your final provisioner.
+  Packer will wait for a default of 5 minutes until the virtual machine is shutdown.
+  The timeout can be changed using the `shutdown_timeout` option.
+
 - `disk_size` (uint) - The size, in megabytes, of the hard disk to create
   for the VM. By default, this is 40 GB.
 

--- a/docs-partials/builder/hyperv/vmcx/Config-not-required.mdx
+++ b/docs-partials/builder/hyperv/vmcx/Config-not-required.mdx
@@ -1,5 +1,12 @@
 <!-- Code generated from the comments of the Config struct in builder/hyperv/vmcx/builder.go; DO NOT EDIT MANUALLY -->
 
+- `disable_shutdown` (bool) - Packer normally halts the virtual machine after all provisioners have
+  run when no `shutdown_command` is defined. If this is set to `true`, Packer
+  *will not* halt the virtual machine but will assume that the VM will shut itself down
+  when it's done, via the preseed.cfg or your final provisioner.
+  Packer will wait for a default of 5 minutes until the virtual machine is shutdown.
+  The timeout can be changed using the `shutdown_timeout` option.
+
 - `clone_from_vmcx_path` (string) - This is the path to a directory containing an exported virtual machine.
 
 - `clone_from_vm_name` (string) - This is the name of the virtual machine to clone from.


### PR DESCRIPTION
Adds a boolean option `disable_shutdown`, in the spirit of the Virtualbox plugin, which when enabled makes the Hyper-V plugin wait for the VM to shut down itself instead of proactively halting it. I happened to need this bit of functionality for the same reason as the original submitter in https://github.com/hashicorp/packer/issues/10630, and since @SwampDragons laid out everything needed I thought I'd give it a shot.

The happy path works for me in my testing. However, ^C doesn't work correctly once Packer goes into the waiting loop. Once the VM goes away, though, Packer cleans up in the usual manner. I'm not sure if that is something I introduced or whether that's because I tested the plugin as its own executable outside of the main Packer executable. I'm not really that well-versed in Go or the plugin structure in general, so I figured I would throw this up and hopefully one of you fine folks could tell me what to fix :D I've attached a log of the issue, in case it helps. 

[ctrl-c not working.txt](https://github.com/hashicorp/packer-plugin-hyperv/files/6412466/ctrl-c.not.working.txt)


Closes #5 


