### PR TITLE
Update Get host IP address to use Get-NetIPAddress commandlet.

### DIFF
--- a/builder/hyperv/common/powershell/hyperv/hyperv.go
+++ b/builder/hyperv/common/powershell/hyperv/hyperv.go
@@ -36,9 +36,7 @@ $HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchN
 if ($HostVMAdapter){
   $HostNetAdapter = Get-NetAdapter | Where-Object { $_.DeviceId -eq $HostVMAdapter.DeviceId }
   if ($HostNetAdapter){
-    $HostNetAdapterIfIndex = @()
-    $HostNetAdapterIfIndex += $HostNetAdapter.ifIndex
-    $HostNetAdapterConfiguration = @(get-wmiobject win32_networkadapterconfiguration -filter "IPEnabled = 'TRUE'") | Where-Object { $HostNetAdapterIfIndex.Contains($_.InterfaceIndex)}
+    $HostNetAdapterConfiguration = @(Get-NetIPAddress -AddressFamily IPv4 -InterfaceIndex $HostNetAdapter.InterfaceIndex | Where-Object SuffixOrigin -notmatch "Link")
     if ($HostNetAdapterConfiguration){
       return @($HostNetAdapterConfiguration.IpAddress)[$addressIndex]
     }


### PR DESCRIPTION
It seems that on Windows 11 built-in internal switches (e. g. _Default Switch_) are not exposed in GUI anymore and also their IP configuration is not returned in the `Win32_NetworkAdapterConfiguration` WMI class that is currently used in Hyper-V Packer builder to get host OS IP address. 

This is example output from my testing Windows 11 machine:
```powershell
PS C:\> $HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName "Default Switch" | Select-Object -First 1
PS C:\> $HostVMAdapter

Name                   IsManagementOs VMName SwitchName     MacAddress   Status IPAddresses
----                   -------------- ------ ----------     ----------   ------ -----------
Container NIC 502b508d True                  Default Switch 00155D02BD79 {Ok}


PS C:\> $HostNetAdapter = Get-NetAdapter | Where-Object { $_.DeviceId -eq $HostVMAdapter.DeviceId }
PS C:\> $HostNetAdapter

Name                      InterfaceDescription                    ifIndex Status       MacAddress             LinkSpeed
----                      --------------------                    ------- ------       ----------             ---------
vEthernet (Default Swi... Hyper-V Virtual Ethernet Adapter             39 Up           00-15-5D-02-BD-79        10 Gbps


PS C:\> $HostNetAdapterIfIndex = @()
PS C:\> $HostNetAdapterIfIndex += $HostNetAdapter.ifIndex
PS C:\> $HostNetAdapterConfiguration = @(get-wmiobject win32_networkadapterconfiguration -filter "IPEnabled = 'TRUE'") | Where-Object { $HostNetAdapterIfIndex.Contains($_.InterfaceIndex)}
PS C:\> $HostNetAdapterConfiguration
PS C:\> $HostNetAdapterConfiguration -eq $null
True
```

I tested on RTM build 22000.194 and on the latest Insider build 22454.1000.

When `Get-NetIPAddress` command/let is used, even for this special-purpose switch (in my case _Default Switch_), IP address of the host OS is returned properly.

```powershell
PS C:\> Get-NetIPAddress -AddressFamily IPv4 -InterfaceIndex $HostNetAdapter.InterfaceIndex | Where-Object SuffixOrigin -notmatch "Link"


IPAddress         : 172.17.240.1
InterfaceIndex    : 39
InterfaceAlias    : vEthernet (Default Switch)
AddressFamily     : IPv4
Type              : Unicast
PrefixLength      : 20
PrefixOrigin      : Manual
SuffixOrigin      : Manual
AddressState      : Preferred
ValidLifetime     : Infinite ([TimeSpan]::MaxValue)
PreferredLifetime : Infinite ([TimeSpan]::MaxValue)
SkipAsSource      : False
PolicyStore       : ActiveStore
```

Using this `Get-NetIPAddress` also works as expected on Windows 10.

Therefore I'd like to propose this change to make it compatible with both Windows 10 and 11. Would this be OK?