### PR TITLE
Add support for running within WSL2

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -35,3 +35,11 @@ $ packer plugins install github.com/hashicorp/hyperv
 - [hyperv-vmcx](packer/integrations/hashicorp/hyperv/latest/components/builder/vmcx) - Clones an existing
   virtual machine, provisions software within the OS, then exports that machine to create an image. This is best for people who have existing base
   images and want to customize them.
+
+### Running from WSL2
+
+This plugin supports being run from WSL2 provided its run from a windows filesystem and the PACKER_CACHE_DIR is set to a path on the windows filesystem.
+
+For example, assuming a Windows username of `user`:
+    
+    /mnt/c/Users/user/$ PACKER_CACHE_DIR=/mnt/c/Users/user/.packer packer build ...

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -13,22 +13,21 @@ import (
 
 	"github.com/hashicorp/packer-plugin-hyperv/builder/hyperv/common/powershell"
 	"github.com/hashicorp/packer-plugin-hyperv/builder/hyperv/common/powershell/hyperv"
+	"github.com/hashicorp/packer-plugin-hyperv/builder/hyperv/common/wsl"
 )
 
 type HypervPS4Driver struct {
 }
 
 func NewHypervPS4Driver() (Driver, error) {
-	appliesTo := "Applies to Windows 8.1, Windows PowerShell 4.0, Windows Server 2012 R2 only"
+	appliesTo := "Applies to Windows 8.1+, Windows PowerShell 4.0, Windows Server 2012 R2+, WSL2 only"
 
-	// Check this is Windows
-	if runtime.GOOS != "windows" {
+	if !wsl.IsWSL() && runtime.GOOS != "windows" {
 		err := fmt.Errorf("%s", appliesTo)
 		return nil, err
 	}
 
 	ps4Driver := &HypervPS4Driver{}
-
 	if err := ps4Driver.Verify(); err != nil {
 		return nil, err
 	}

--- a/builder/hyperv/common/step_mount_dvddrive.go
+++ b/builder/hyperv/common/step_mount_dvddrive.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/packer-plugin-hyperv/builder/hyperv/common/wsl"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
@@ -33,6 +34,16 @@ func (s *StepMountDvdDrive) Run(ctx context.Context, state multistep.StateBag) m
 	} else {
 		log.Println("No dvd disk, not attaching.")
 		return multistep.ActionContinue
+	}
+
+	if wsl.IsWSL() {
+		var err error
+		isoPath, err = wsl.ConvertWSlPathToWindowsPath(isoPath)
+		if err != nil {
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
 	}
 
 	// Determine if its a virtual hdd to mount

--- a/builder/hyperv/common/wsl/wsl.go
+++ b/builder/hyperv/common/wsl/wsl.go
@@ -1,0 +1,112 @@
+package wsl
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func IsWSL() bool {
+	var isWSL bool
+	isWSL = false
+	if runtime.GOOS == "linux" {
+		content, err := ioutil.ReadFile("/proc/version")
+		if err == nil {
+			s := string(content)
+			if strings.Contains(s, "WSL2") {
+				isWSL = true
+			}
+		}
+	}
+	return isWSL
+}
+
+func GetWSlTemp() (string, error) {
+
+	var stdout, stderr bytes.Buffer
+	args := make([]string, 3)
+	args[0] = "/c"
+	args[1] = "echo"
+
+	args[2] = "%TEMP%"
+	command := exec.Command("cmd.exe", args...)
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	err := command.Run()
+
+	stderrString := strings.TrimSpace(stderr.String())
+
+	if _, ok := err.(*exec.ExitError); ok {
+		err = fmt.Errorf("Error getting wsl TEMP dir: %s", stderrString)
+		return "", err
+	}
+
+	if len(stderrString) > 0 {
+		err = fmt.Errorf("Error getting wsl TEMP dir: %s", stderrString)
+		return "", err
+	}
+
+	return strings.TrimSpace(stdout.String()), err
+}
+
+func ConvertWindowsPathToWSlPath(winPath string) (string, error) {
+
+	var stdout, stderr bytes.Buffer
+	args := make([]string, 3)
+	args[0] = "-a"
+	args[1] = "-u"
+
+	args[2] = winPath
+	command := exec.Command("wslpath", args...)
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	err := command.Run()
+
+	stderrString := strings.TrimSpace(stderr.String())
+
+	if _, ok := err.(*exec.ExitError); ok {
+		err = fmt.Errorf("wslpath error: %s", stderrString)
+		return "", err
+	}
+
+	if len(stderrString) > 0 {
+		err = fmt.Errorf("wslpath error: %s", stderrString)
+		return "", err
+	}
+
+	return strings.TrimSpace(stdout.String()), err
+}
+
+func ConvertWSlPathToWindowsPath(wslPath string) (string, error) {
+
+	var stdout, stderr bytes.Buffer
+	args := make([]string, 3)
+	args[0] = "-a"
+	args[1] = "-w"
+
+	args[2] = wslPath
+	command := exec.Command("wslpath", args...)
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	err := command.Run()
+
+	stderrString := strings.TrimSpace(stderr.String())
+
+	if _, ok := err.(*exec.ExitError); ok {
+		err = fmt.Errorf("wslpath error: %s", stderrString)
+		return "", err
+	}
+
+	if len(stderrString) > 0 {
+		err = fmt.Errorf("wslpath error: %s", stderrString)
+		return "", err
+	}
+
+	return strings.TrimSpace(stdout.String()), err
+}

--- a/builder/hyperv/common/wsl/wsl_test.go
+++ b/builder/hyperv/common/wsl/wsl_test.go
@@ -1,0 +1,55 @@
+package wsl
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetWSlTemp(t *testing.T) {
+
+	if !IsWSL() {
+		t.Skipf("not running in WSL")
+		return
+	}
+	tempDir, err := GetWSlTemp()
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+	if tempDir == "" {
+		t.Fatalf("tempDir is not polulated correctly")
+	}
+}
+
+func TestConvertWindowsPathToWSlPath(t *testing.T) {
+
+	if !IsWSL() {
+		t.Skipf("not running in WSL")
+		return
+	}
+	wslPath, err := ConvertWindowsPathToWSlPath("C:\\Users\\User\\path with spaces")
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+	if wslPath == "" {
+		t.Fatalf("wslPath is not polulated correctly")
+	}
+}
+
+func TestConvertWSlPathToWindowsPath(t *testing.T) {
+
+	if !IsWSL() {
+		t.Skipf("not running in WSL")
+		return
+	}
+	curDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd should not have error: %s", err)
+	}
+	winPath, err := ConvertWSlPathToWindowsPath(curDir)
+	if err != nil {
+		t.Fatalf("ConvertWSlPathToWindowsPath should not have error: %s", err)
+	}
+	if winPath == "" {
+		t.Fatalf("wslPath is not polulated correctly")
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,3 +35,11 @@ $ packer plugins install github.com/hashicorp/hyperv
 - [hyperv-vmcx](packer/integrations/hashicorp/hyperv/latest/components/builder/vmcx) - Clones an existing
   virtual machine, provisions software within the OS, then exports that machine to create an image. This is best for people who have existing base
   images and want to customize them.
+
+### Running from WSL2
+
+This plugin supports being run from WSL2 provided its run from a windows filesystem and the PACKER_CACHE_DIR is set to a path on the windows filesystem.
+
+For example, assuming a Windows username of `user`:
+    
+    /mnt/c/Users/user/$ PACKER_CACHE_DIR=/mnt/c/Users/user/.packer packer build ...


### PR DESCRIPTION
Support for running from within WSL2. 

Similar to vagrant it will work when run from a windows filesystem within wsl i.e. `/mnt/c/Users/user/... `
Further, `PACKER_CACHE_DIR` needs to be set to a path on the windows filesystem.

This is all I needed for my testing to work.
`/mnt/c/Users/user/packer-plugin-hyperv$ PACKER_CACHE_DIR=/mnt/c/Users/user/.packer packer build ...`


Closes #38

