### PR TITLE
Add support for disk_size in hyperv-vmcx builder (#63)

### DIFF
--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -81,6 +81,8 @@ type Driver interface {
 
 	CloneVirtualMachine(string, string, string, bool, string, string, string, int64, string, bool) error
 
+	ResizeVirtualMachineVhd(string, uint64) error
+
 	DeleteVirtualMachine(string) error
 
 	GetVirtualMachineGeneration(string) (uint, error)

--- a/builder/hyperv/common/driver_mock.go
+++ b/builder/hyperv/common/driver_mock.go
@@ -155,6 +155,11 @@ type DriverMock struct {
 	CloneVirtualMachine_Copy                  bool
 	CloneVirtualMachine_Err                   error
 
+	ResizeVirtualMachineVhd_Called         bool
+	ResizeVirtualMachineVhd_VmName         string
+	ResizeVirtualMachineVhd_newSizeInBytes uint64
+	ResizeVirtualMachineVhd_Err            error
+
 	DeleteVirtualMachine_Called bool
 	DeleteVirtualMachine_VmName string
 	DeleteVirtualMachine_Err    error
@@ -475,6 +480,14 @@ func (d *DriverMock) CloneVirtualMachine(cloneFromVmcxPath string, cloneFromVmNa
 	d.CloneVirtualMachine_Copy = copyTF
 
 	return d.CloneVirtualMachine_Err
+}
+
+func (d *DriverMock) ResizeVirtualMachineVhd(vmName string, newSizeInBytes uint64) error {
+	d.ResizeVirtualMachineVhd_Called = true
+	d.ReplaceVirtualMachineNetworkAdapter_VmName = vmName
+	d.ResizeVirtualMachineVhd_newSizeInBytes = newSizeInBytes
+
+	return d.ResizeVirtualMachineVhd_Err
 }
 
 func (d *DriverMock) DeleteVirtualMachine(vmName string) error {

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -204,6 +204,10 @@ func (d *HypervPS4Driver) CloneVirtualMachine(cloneFromVmcxPath string, cloneFro
 		cloneAllSnapshots, vmName, path, harddrivePath, ram, switchName, copyTF)
 }
 
+func (d *HypervPS4Driver) ResizeVirtualMachineVhd(vmName string, newSizeInBytes uint64) error {
+	return hyperv.ResizeVirtualMachineVhd(vmName, newSizeInBytes)
+}
+
 func (d *HypervPS4Driver) DeleteVirtualMachine(vmName string) error {
 	return hyperv.DeleteVirtualMachine(vmName)
 }

--- a/builder/hyperv/common/step_resize_vhd.go
+++ b/builder/hyperv/common/step_resize_vhd.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+// This resizes the first vhd on the virtual machine to the specified DiskSize (in MB)
+//
+type StepResizeVhd struct {
+	DiskSize *uint
+}
+
+func (s *StepResizeVhd) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	if s.DiskSize == nil {
+		return multistep.ActionContinue
+	}
+
+	driver := state.Get("driver").(Driver)
+	ui := state.Get("ui").(packersdk.Ui)
+	ui.Say("Resizing vhd...")
+
+	vmName := state.Get("vmName").(string)
+
+	// convert the MB to bytes
+	newDiskSizeInBytes := uint64(*s.DiskSize) * 1024 * 1024
+
+	err := driver.ResizeVirtualMachineVhd(vmName, newDiskSizeInBytes)
+	if err != nil {
+		err := fmt.Errorf("Error resizing VHD: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepResizeVhd) Cleanup(state multistep.StateBag) {
+	// do nothing
+}

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -59,6 +59,9 @@ type Config struct {
 	// Packer will wait for a default of 5 minutes until the virtual machine is shutdown.
 	// The timeout can be changed using the `shutdown_timeout` option.
 	DisableShutdown bool `mapstructure:"disable_shutdown" required:"false"`
+	// The size, in megabytes, of the primary hard disk
+	// for the VM. By default, this is the same as the cloned VM.
+	DiskSize *uint `mapstructure:"disk_size" required:"false"`
 	// This is the path to a directory containing an exported virtual machine.
 	CloneFromVMCXPath string `mapstructure:"clone_from_vmcx_path"`
 	// This is the name of the virtual machine to clone from.
@@ -280,6 +283,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			KeepRegistered:                 b.config.KeepRegistered,
 			AdditionalDiskSize:             b.config.AdditionalDiskSize,
 			DiskBlockSize:                  b.config.DiskBlockSize,
+		},
+
+		&hypervcommon.StepResizeVhd{
+			DiskSize: b.config.DiskSize,
 		},
 
 		&hypervcommon.StepEnableIntegrationService{},

--- a/builder/hyperv/vmcx/builder.hcl2spec.go
+++ b/builder/hyperv/vmcx/builder.hcl2spec.go
@@ -118,6 +118,7 @@ type FlatConfig struct {
 	ShutdownCommand                *string           `mapstructure:"shutdown_command" required:"false" cty:"shutdown_command" hcl:"shutdown_command"`
 	ShutdownTimeout                *string           `mapstructure:"shutdown_timeout" required:"false" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
 	DisableShutdown                *bool             `mapstructure:"disable_shutdown" required:"false" cty:"disable_shutdown" hcl:"disable_shutdown"`
+	DiskSize                       *uint             `mapstructure:"disk_size" required:"false" cty:"disk_size" hcl:"disk_size"`
 	CloneFromVMCXPath              *string           `mapstructure:"clone_from_vmcx_path" cty:"clone_from_vmcx_path" hcl:"clone_from_vmcx_path"`
 	CloneFromVMName                *string           `mapstructure:"clone_from_vm_name" cty:"clone_from_vm_name" hcl:"clone_from_vm_name"`
 	CloneFromSnapshotName          *string           `mapstructure:"clone_from_snapshot_name" required:"false" cty:"clone_from_snapshot_name" hcl:"clone_from_snapshot_name"`
@@ -246,6 +247,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"shutdown_command":                 &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout":                 &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
 		"disable_shutdown":                 &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
+		"disk_size":                        &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"clone_from_vmcx_path":             &hcldec.AttrSpec{Name: "clone_from_vmcx_path", Type: cty.String, Required: false},
 		"clone_from_vm_name":               &hcldec.AttrSpec{Name: "clone_from_vm_name", Type: cty.String, Required: false},
 		"clone_from_snapshot_name":         &hcldec.AttrSpec{Name: "clone_from_snapshot_name", Type: cty.String, Required: false},

--- a/docs-partials/builder/hyperv/vmcx/Config-not-required.mdx
+++ b/docs-partials/builder/hyperv/vmcx/Config-not-required.mdx
@@ -7,6 +7,9 @@
   Packer will wait for a default of 5 minutes until the virtual machine is shutdown.
   The timeout can be changed using the `shutdown_timeout` option.
 
+- `disk_size` (\*uint) - The size, in megabytes, of the primary hard disk
+  for the VM. By default, this is the same as the cloned VM.
+
 - `clone_from_vmcx_path` (string) - This is the path to a directory containing an exported virtual machine.
 
 - `clone_from_vm_name` (string) - This is the name of the virtual machine to clone from.


### PR DESCRIPTION
Added capability to use disk_size in order to resize (grow in size) the primary disk on a cloned VM.  This will only work when the primary disk is of a type which can be resized (not a differencing disk).

Closes #63 

