### PR TITLE
Include hidden network adapters

### DIFF
--- a/builder/hyperv/common/powershell/hyperv/hyperv.go
+++ b/builder/hyperv/common/powershell/hyperv/hyperv.go
@@ -34,7 +34,7 @@ func GetHostAdapterIpAddressForSwitch(switchName string) (string, error) {
 param([string]$switchName, [int]$addressIndex)
 $HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName | Select-Object -First 1
 if ($HostVMAdapter){
-  $HostNetAdapter = Get-NetAdapter | Where-Object { $_.DeviceId -eq $HostVMAdapter.DeviceId }
+  $HostNetAdapter = Get-NetAdapter -IncludeHidden | Where-Object { $_.DeviceId -eq $HostVMAdapter.DeviceId }
   if ($HostNetAdapter){
     $HostNetAdapterConfiguration = @(Get-NetIPAddress -AddressFamily IPv4 -InterfaceIndex $HostNetAdapter.InterfaceIndex | Where-Object SuffixOrigin -notmatch "Link")
     if ($HostNetAdapterConfiguration){


### PR DESCRIPTION
On Windows 11 22H2 the "Default Switch" network adapter is hidden,
preventing the IP address from being found. Including hidden adapters
resolves the issue.

Verified on Windows 10 21H2 and Windows 11 22H2.

Closes #65
