### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -12,12 +12,12 @@ The HyperV Packer builder is able to create
 [Hyper-V](https://www.microsoft.com/en-us/server-cloud/solutions/virtualization.aspx)
 virtual machines and export them.
 
-- [hyperv-iso](/docs/builders/hyperv-iso) - Starts from an ISO file,
+- [hyperv-iso](/packer/plugins/builders/hyperv/iso) - Starts from an ISO file,
   creates a brand new Hyper-V VM, installs an OS, provisions software within
   the OS, then exports that machine to create an image. This is best for
   people who want to start from scratch.
 
-- [hyperv-vmcx](/docs/builders/hyperv-vmcx) - Clones an an existing
+- [hyperv-vmcx](/packer/plugins/builders/hyperv/vmcx) - Clones an an existing
   virtual machine, provisions software within the OS, then exports that
   machine to create an image. This is best for people who have existing base
   images and want to customize them.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -66,7 +66,7 @@ are organized below into two categories: required and optional. Within each
 category, the available options are alphabetized and described.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 ### Optional:

--- a/docs/builders/vmcx.mdx
+++ b/docs/builders/vmcx.mdx
@@ -67,7 +67,7 @@ are organized below into two categories: required and optional. Within each
 category, the available options are alphabetized and described.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 ## ISO Configuration Reference
@@ -198,7 +198,7 @@ To hold the `c` key down, you would use `<cOn>`. Likewise, `<cOff>` to release.
 ### Templates inside boot command
 
 In addition to the special keys, each command to type is treated as a
-[template engine](/docs/templates/legacy_json_templates/engine). The
+[template engine](/packer/docs/templates/legacy_json_templates/engine). The
 available variables are:
 
 - `HTTPIP` and `HTTPPort` - The IP and port, respectively of an HTTP server


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them
