### PR TITLE
Fix Host IP detection on Windows 11, 22H2.

### DIFF
--- a/builder/hyperv/common/powershell/hyperv/hyperv.go
+++ b/builder/hyperv/common/powershell/hyperv/hyperv.go
@@ -34,7 +34,7 @@ func GetHostAdapterIpAddressForSwitch(switchName string) (string, error) {
 param([string]$switchName, [int]$addressIndex)
 $HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName | Select-Object -First 1
 if ($HostVMAdapter){
-  $HostNetAdapter = Get-NetAdapter | Where-Object { $_.DeviceId -eq $HostVMAdapter.DeviceId }
+  $HostNetAdapter = Get-NetAdapter -IncludeHidden | Where-Object { $_.DeviceId -eq $HostVMAdapter.DeviceId }
   if ($HostNetAdapter){
     $HostNetAdapterConfiguration = @(Get-NetIPAddress -AddressFamily IPv4 -InterfaceIndex $HostNetAdapter.InterfaceIndex | Where-Object SuffixOrigin -notmatch "Link")
     if ($HostNetAdapterConfiguration){


### PR DESCRIPTION
Starting with version 22H2 of Windows 11 (build 22621+) there is once again a change in how vNics used with `Default Switch` NAT connectivity are used. They are now hidden both in GUI (`ncpa.cpl`) and in PowerShell output of `Get-NetAdapter` command. Therefore parameter `-IncludeHidden` is now required to properly detect the IP address of a host machine when using `Default Switch` for building with Hyper-V.

This change should be backwards compatible with previous versions of Windows.