### PR TITLE
bump go 1.18 to 1.19

### DIFF
--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -140,12 +140,12 @@ func (d *HypervPS4Driver) GetVirtualMachineNetworkAdapterAddress(vmName string) 
 	return hyperv.GetVirtualMachineNetworkAdapterAddress(vmName)
 }
 
-//Set the vlan to use for switch
+// Set the vlan to use for switch
 func (d *HypervPS4Driver) SetNetworkAdapterVlanId(switchName string, vlanId string) error {
 	return hyperv.SetNetworkAdapterVlanId(switchName, vlanId)
 }
 
-//Set the vlan to use for machine
+// Set the vlan to use for machine
 func (d *HypervPS4Driver) SetVirtualMachineVlanId(vmName string, vlanId string) error {
 	return hyperv.SetVirtualMachineVlanId(vmName, vlanId)
 }
@@ -154,7 +154,7 @@ func (d *HypervPS4Driver) SetVmNetworkAdapterMacAddress(vmName string, mac strin
 	return hyperv.SetVmNetworkAdapterMacAddress(vmName, mac)
 }
 
-//Replace the network adapter with a (non-)legacy adapter
+// Replace the network adapter with a (non-)legacy adapter
 func (d *HypervPS4Driver) ReplaceVirtualMachineNetworkAdapter(vmName string, virtual bool) error {
 	return hyperv.ReplaceVirtualMachineNetworkAdapter(vmName, virtual)
 }

--- a/builder/hyperv/common/powershell/hyperv/hyperv.go
+++ b/builder/hyperv/common/powershell/hyperv/hyperv.go
@@ -327,7 +327,6 @@ Hyper-V\Set-VMFloppyDiskDrive -VMName $vmName -Path $null
 //
 // For examples of what this template will generate, you can look at the
 // test cases in ./hyperv_test.go
-//
 func getCreateVMScript(opts *scriptOptions) (string, error) {
 
 	if opts.FixedVHD && opts.Generation == 2 {

--- a/builder/hyperv/common/step_clone_vm.go
+++ b/builder/hyperv/common/step_clone_vm.go
@@ -17,7 +17,8 @@ import (
 // This step clones an existing virtual machine.
 //
 // Produces:
-//   VMName string - The name of the VM
+//
+//	VMName string - The name of the VM
 type StepCloneVM struct {
 	CloneFromVMCXPath              string
 	CloneFromVMName                string

--- a/builder/hyperv/common/step_create_external_switch.go
+++ b/builder/hyperv/common/step_create_external_switch.go
@@ -15,7 +15,8 @@ import (
 // This step creates an external switch for the VM.
 //
 // Produces:
-//   SwitchName string - The name of the Switch
+//
+//	SwitchName string - The name of the Switch
 type StepCreateExternalSwitch struct {
 	SwitchName    string
 	oldSwitchName string

--- a/builder/hyperv/common/step_create_switch.go
+++ b/builder/hyperv/common/step_create_switch.go
@@ -20,7 +20,8 @@ const (
 // This step creates switch for VM.
 //
 // Produces:
-//   SwitchName string - The name of the Switch
+//
+//	SwitchName string - The name of the Switch
 type StepCreateSwitch struct {
 	// Specifies the name of the switch to be created.
 	SwitchName string

--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -17,7 +17,8 @@ import (
 // This step creates the actual virtual machine.
 //
 // Produces:
-//   VMName string - The name of the VM
+//
+//	VMName string - The name of the VM
 type StepCreateVM struct {
 	VMName                         string
 	SwitchName                     string

--- a/builder/hyperv/common/step_resize_vhd.go
+++ b/builder/hyperv/common/step_resize_vhd.go
@@ -12,7 +12,6 @@ import (
 )
 
 // This resizes the first vhd on the virtual machine to the specified DiskSize (in MB)
-//
 type StepResizeVhd struct {
 	DiskSize *uint
 }

--- a/builder/hyperv/common/step_shutdown.go
+++ b/builder/hyperv/common/step_shutdown.go
@@ -19,13 +19,15 @@ import (
 // but ultimately forcefully shuts it down if that fails.
 //
 // Uses:
-//   communicator packersdk.Communicator
-//   driver       Driver
-//   ui           packersdk.Ui
-//   vmName       string
+//
+//	communicator packersdk.Communicator
+//	driver       Driver
+//	ui           packersdk.Ui
+//	vmName       string
 //
 // Produces:
-//   <nothing>
+//
+//	<nothing>
 type StepShutdown struct {
 	Command         string
 	Timeout         time.Duration

--- a/builder/hyperv/vmcx/builder_test.go
+++ b/builder/hyperv/vmcx/builder_test.go
@@ -149,7 +149,7 @@ func TestBuilderPrepare_ExportedMachinePathExists(t *testing.T) {
 	}
 }
 
-//nolint
+// nolint
 func disabled_TestBuilderPrepare_CloneFromVmSettingUsedSoNoCloneFromVmcxPathRequired(t *testing.T) {
 	var b Builder
 	config := testConfig()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/packer-plugin-hyperv
 
-go 1.18
+go 1.19
 
 require (
 	github.com/hashicorp/hcl/v2 v2.13.0


### PR DESCRIPTION
- Upgrade plugin for integrations library
- docs: update for integrations
- go.mod: bump go version from 1.18 to 1.19
