### PR TITLE
fix: #7

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -318,6 +318,8 @@ created, must be empty prior to running the builder. By default this is
 
 - `keep_registered` (bool) - If "true", Packer will not delete the VM from
   The Hyper-V manager.
+  The resulting VM will be housed in a randomly generated folder under %TEMP% by default.
+  You can set the `temp_path` variable to change the location of the folder.
 
 - `skip_compaction` (bool) - If true skip compacting the hard disk for
   the virtual machine when exporting. This defaults to false.

--- a/.web-docs/components/builder/vmcx/README.md
+++ b/.web-docs/components/builder/vmcx/README.md
@@ -345,6 +345,8 @@ In HCL2:
 
 - `keep_registered` (bool) - If "true", Packer will not delete the VM from
   The Hyper-V manager.
+  The resulting VM will be housed in a randomly generated folder under %TEMP% by default.
+  You can set the `temp_path` variable to change the location of the folder.
 
 - `skip_compaction` (bool) - If true skip compacting the hard disk for
   the virtual machine when exporting. This defaults to false.

--- a/builder/hyperv/common/config.go
+++ b/builder/hyperv/common/config.go
@@ -139,6 +139,8 @@ type CommonConfig struct {
 	Version string `mapstructure:"configuration_version" required:"false"`
 	// If "true", Packer will not delete the VM from
 	// The Hyper-V manager.
+	// The resulting VM will be housed in a randomly generated folder under %TEMP% by default.
+	// You can set the `temp_path` variable to change the location of the folder.
 	KeepRegistered bool `mapstructure:"keep_registered" required:"false"`
 	// If true skip compacting the hard disk for
 	// the virtual machine when exporting. This defaults to false.

--- a/builder/hyperv/common/step_create_build_dir.go
+++ b/builder/hyperv/common/step_create_build_dir.go
@@ -24,6 +24,9 @@ type StepCreateBuildDir struct {
 	// The full path to the build directory. This is the concatenation of
 	// TempPath plus a directory uniquely named for the build
 	buildDir string
+	// If true, the build directory will not be deleted when the step
+	// Cleanup() method is called
+	KeepRegistered bool
 }
 
 // Creates the main directory used to house the VMs files and folders
@@ -62,6 +65,12 @@ func (s *StepCreateBuildDir) Cleanup(state multistep.StateBag) {
 	}
 
 	ui := state.Get("ui").(packersdk.Ui)
+
+	if s.KeepRegistered {
+		ui.Say("Keeping build directory...")
+		return
+	}
+
 	ui.Say("Deleting build directory...")
 
 	err := os.RemoveAll(s.buildDir)

--- a/builder/hyperv/common/step_create_build_dir.go
+++ b/builder/hyperv/common/step_create_build_dir.go
@@ -66,7 +66,10 @@ func (s *StepCreateBuildDir) Cleanup(state multistep.StateBag) {
 
 	ui := state.Get("ui").(packersdk.Ui)
 
-	if s.KeepRegistered {
+	_, cancelled := state.GetOk(multistep.StateCancelled)
+	_, halted := state.GetOk(multistep.StateHalted)
+
+	if s.KeepRegistered && !(cancelled || halted) {
 		ui.Say("Keeping build directory...")
 		return
 	}

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -202,7 +202,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	steps := []multistep.Step{
 		&hypervcommon.StepCreateBuildDir{
-			TempPath: b.config.TempPath,
+			TempPath:       b.config.TempPath,
+			KeepRegistered: b.config.KeepRegistered,
 		},
 		&commonsteps.StepOutputDir{
 			Force: b.config.PackerForce,

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -243,7 +243,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	steps := []multistep.Step{
 		&hypervcommon.StepCreateBuildDir{
-			TempPath: b.config.TempPath,
+			TempPath:       b.config.TempPath,
+			KeepRegistered: b.config.KeepRegistered,
 		},
 		&commonsteps.StepOutputDir{
 			Force: b.config.PackerForce,

--- a/docs-partials/builder/hyperv/common/CommonConfig-not-required.mdx
+++ b/docs-partials/builder/hyperv/common/CommonConfig-not-required.mdx
@@ -97,6 +97,8 @@
 
 - `keep_registered` (bool) - If "true", Packer will not delete the VM from
   The Hyper-V manager.
+  The resulting VM will be housed in a randomly generated folder under %TEMP% by default.
+  You can set the `temp_path` variable to change the location of the folder.
 
 - `skip_compaction` (bool) - If true skip compacting the hard disk for
   the virtual machine when exporting. This defaults to false.


### PR DESCRIPTION
When the `keep_registered` flag was true, the VM stayed in HyperV manager, but its files were deleted anyway, making it impossible to use the VM as-is.

This PR makes the VM's files cleanup look for the `keep_registered` flag, and if set to true, will not delete the VM files, keeping it usable.

However, the VM files stays in the temp folder. We may want to move the files to another location beforehand if the flag is up.

This PR closes #7 .

