### PR TITLE
Add a leading slash to fix links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,12 +27,12 @@ $ packer plugins install github.com/hashicorp/hyperv
 
 #### Builders
 
-- [hyperv-iso](packer/integrations/hashicorp/hyperv/latest/components/builder/iso) - Starts from an ISO file,
+- [hyperv-iso](/packer/integrations/hashicorp/hyperv/latest/components/builder/iso) - Starts from an ISO file,
   creates a brand new Hyper-V VM, installs an OS, provisions software within
   the OS, then exports that machine to create an image. This is best for
   people who want to start from scratch.
 
-- [hyperv-vmcx](packer/integrations/hashicorp/hyperv/latest/components/builder/vmcx) - Clones an existing
+- [hyperv-vmcx](/packer/integrations/hashicorp/hyperv/latest/components/builder/vmcx) - Clones an existing
   virtual machine, provisions software within the OS, then exports that machine to create an image. This is best for people who have existing base
   images and want to customize them.
 


### PR DESCRIPTION
Adding a leading slash before "packer" to fix these the last two links on: https://developer.hashicorp.com/packer/integrations/hashicorp/hyperv
