### PR TITLE
bugfix: use arp when CIM returns no ip

### DIFF
--- a/builder/hyperv/common/powershell/hyperv/hyperv.go
+++ b/builder/hyperv/common/powershell/hyperv/hyperv.go
@@ -1381,11 +1381,14 @@ try {
     $ip_details = (Get-CimAssociatedInstance -InputObject $vm_info -ResultClassName Msvm_KvpExchangeComponent).GuestIntrinsicExchangeItems | %{ [xml]$_ } | ?{ $_.SelectSingleNode("/INSTANCE/PROPERTY[@NAME='Name']/VALUE[child::text()='NetworkAddressIPv4']") }
 
     if ($null -eq $ip_details) {
-      return ""
-    }
-
-    $ip_addresses = $ip_details.SelectSingleNode("/INSTANCE/PROPERTY[@NAME='Data']/VALUE/child::text()").Value
-    $ip = ($ip_addresses -split ";")[0]
+	  $ip = ((Get-NetNeighbor | Where-Object {$_.LinkLayerAddress.ToLower().Replace("-","") -eq (Hyper-V\Get-VMNetworkAdapter $vm.Name | select-object -first 1).MacAddress.ToLower()}) | Where-Object {$_.IPAddress -Match "\." } | select -first 1).IPAddress
+	  if ($null -eq $ip){
+		return ""
+	  }
+	} else {
+	  $ip_addresses = $ip_details.SelectSingleNode("/INSTANCE/PROPERTY[@NAME='Data']/VALUE/child::text()").Value
+	  $ip = ($ip_addresses -split ";")[0]
+	}
   }
 } catch {
   return ""


### PR DESCRIPTION
On windows 11 pro using the "Default Switch" or any other internal switch I notice that Ubuntu VMs hang at the step "Waiting for SSH to become available...".  I believe that this is because we rely on CIM Hyper-V calls that fail to return IP addresses of running machines, they do however return MAC addresses. This could be due to many factors but most likely the requirement for Hyper-V extensions needed to be loaded on linux guest VMs.

This change resolves the issue by doing an ARP table mac address lookup and comparing it to the Hyper-V VM's first NIC mac, then finding the first IPv4 address. This resolved my issue, and is just an additional check to perform before giving up on SSH ip lookup.

Can be improved and re-written if IPv6 and Multi-Nic logic is needed but my case was a simple one.  