### PR TITLE
Fix #121

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -323,6 +323,8 @@ created, must be empty prior to running the builder. By default this is
 
 - `skip_compaction` (bool) - If true skip compacting the hard disk for
   the virtual machine when exporting. This defaults to false.
+  
+  **NB** `keep_registered` is mutually exclusive with `skip_export`.
 
 - `skip_export` (bool) - If true Packer will skip the export of the VM.
   If you are interested only in the VHD/VHDX files, you can enable this
@@ -334,6 +336,8 @@ created, must be empty prior to running the builder. By default this is
   machines by launching a GUI that shows the console of the machine being
   built. When this value is set to true, the machine will start without a
   console.
+  
+  **NB** `skip_export` is mutually exclusive with `keep_registered`.
 
 - `first_boot_device` (string) - When configured, determines the device or device type that is given preferential
   treatment when choosing a boot device.

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -318,6 +318,8 @@ created, must be empty prior to running the builder. By default this is
 
 - `keep_registered` (bool) - If "true", Packer will not delete the VM from
   The Hyper-V manager.
+  The resulting VM will be housed in a randomly generated folder under %TEMP% by default.
+  You can set the `temp_path` variable to change the location of the folder.
 
 - `skip_compaction` (bool) - If true skip compacting the hard disk for
   the virtual machine when exporting. This defaults to false.

--- a/.web-docs/components/builder/vmcx/README.md
+++ b/.web-docs/components/builder/vmcx/README.md
@@ -345,6 +345,8 @@ In HCL2:
 
 - `keep_registered` (bool) - If "true", Packer will not delete the VM from
   The Hyper-V manager.
+  The resulting VM will be housed in a randomly generated folder under %TEMP% by default.
+  You can set the `temp_path` variable to change the location of the folder.
 
 - `skip_compaction` (bool) - If true skip compacting the hard disk for
   the virtual machine when exporting. This defaults to false.

--- a/.web-docs/components/builder/vmcx/README.md
+++ b/.web-docs/components/builder/vmcx/README.md
@@ -350,6 +350,8 @@ In HCL2:
 
 - `skip_compaction` (bool) - If true skip compacting the hard disk for
   the virtual machine when exporting. This defaults to false.
+  
+  **NB** `keep_registered` is mutually exclusive with `skip_export`.
 
 - `skip_export` (bool) - If true Packer will skip the export of the VM.
   If you are interested only in the VHD/VHDX files, you can enable this
@@ -361,6 +363,8 @@ In HCL2:
   machines by launching a GUI that shows the console of the machine being
   built. When this value is set to true, the machine will start without a
   console.
+  
+  **NB** `skip_export` is mutually exclusive with `keep_registered`.
 
 - `first_boot_device` (string) - When configured, determines the device or device type that is given preferential
   treatment when choosing a boot device.

--- a/builder/hyperv/common/config.go
+++ b/builder/hyperv/common/config.go
@@ -139,6 +139,8 @@ type CommonConfig struct {
 	Version string `mapstructure:"configuration_version" required:"false"`
 	// If "true", Packer will not delete the VM from
 	// The Hyper-V manager.
+	// The resulting VM will be housed in a randomly generated folder under %TEMP% by default.
+	// You can set the `temp_path` variable to change the location of the folder.
 	KeepRegistered bool `mapstructure:"keep_registered" required:"false"`
 	// If true skip compacting the hard disk for
 	// the virtual machine when exporting. This defaults to false.

--- a/builder/hyperv/common/config.go
+++ b/builder/hyperv/common/config.go
@@ -144,6 +144,8 @@ type CommonConfig struct {
 	KeepRegistered bool `mapstructure:"keep_registered" required:"false"`
 	// If true skip compacting the hard disk for
 	// the virtual machine when exporting. This defaults to false.
+	//
+	// **NB** `keep_registered` is mutually exclusive with `skip_export`.
 	SkipCompaction bool `mapstructure:"skip_compaction" required:"false"`
 	// If true Packer will skip the export of the VM.
 	// If you are interested only in the VHD/VHDX files, you can enable this
@@ -155,6 +157,8 @@ type CommonConfig struct {
 	// machines by launching a GUI that shows the console of the machine being
 	// built. When this value is set to true, the machine will start without a
 	// console.
+	//
+	// **NB** `skip_export` is mutually exclusive with `keep_registered`.
 	Headless bool `mapstructure:"headless" required:"false"`
 	// When configured, determines the device or device type that is given preferential
 	// treatment when choosing a boot device.

--- a/builder/hyperv/common/step_create_build_dir.go
+++ b/builder/hyperv/common/step_create_build_dir.go
@@ -24,6 +24,9 @@ type StepCreateBuildDir struct {
 	// The full path to the build directory. This is the concatenation of
 	// TempPath plus a directory uniquely named for the build
 	buildDir string
+	// If true, the build directory will not be deleted when the step
+	// Cleanup() method is called
+	KeepRegistered bool
 }
 
 // Creates the main directory used to house the VMs files and folders
@@ -62,6 +65,12 @@ func (s *StepCreateBuildDir) Cleanup(state multistep.StateBag) {
 	}
 
 	ui := state.Get("ui").(packersdk.Ui)
+
+	if s.KeepRegistered {
+		ui.Say("Keeping build directory...")
+		return
+	}
+
 	ui.Say("Deleting build directory...")
 
 	err := os.RemoveAll(s.buildDir)

--- a/builder/hyperv/common/step_create_build_dir.go
+++ b/builder/hyperv/common/step_create_build_dir.go
@@ -66,7 +66,10 @@ func (s *StepCreateBuildDir) Cleanup(state multistep.StateBag) {
 
 	ui := state.Get("ui").(packersdk.Ui)
 
-	if s.KeepRegistered {
+	_, cancelled := state.GetOk(multistep.StateCancelled)
+	_, halted := state.GetOk(multistep.StateHalted)
+
+	if s.KeepRegistered && !(cancelled || halted) {
 		ui.Say("Keeping build directory...")
 		return
 	}

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -154,6 +154,13 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	// Errors
 
+	if b.config.SkipExport {
+		if b.config.KeepRegistered {
+			err = errors.New("skip_export and keep_registered are mutually exclusive.")
+			errs = packersdk.MultiErrorAppend(errs, err)
+		}
+	}
+
 	if b.config.Generation > 1 && b.config.FixedVHD {
 		err = errors.New("Fixed VHD disks are only supported on Generation 1 virtual machines.")
 		errs = packersdk.MultiErrorAppend(errs, err)

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -202,7 +202,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	steps := []multistep.Step{
 		&hypervcommon.StepCreateBuildDir{
-			TempPath: b.config.TempPath,
+			TempPath:       b.config.TempPath,
+			KeepRegistered: b.config.KeepRegistered,
 		},
 		&commonsteps.StepOutputDir{
 			Force: b.config.PackerForce,

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -243,7 +243,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	steps := []multistep.Step{
 		&hypervcommon.StepCreateBuildDir{
-			TempPath: b.config.TempPath,
+			TempPath:       b.config.TempPath,
+			KeepRegistered: b.config.KeepRegistered,
 		},
 		&commonsteps.StepOutputDir{
 			Force: b.config.PackerForce,

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -218,6 +218,15 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 				"will forcibly halt the virtual machine, which may result in data loss.")
 	}
 
+	// Errors
+
+	if b.config.SkipExport {
+		if b.config.KeepRegistered {
+			err = errors.New("skip_export and keep_registered are mutually exclusive.")
+			errs = packersdk.MultiErrorAppend(errs, err)
+		}
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warnings, errs
 	}

--- a/docs-partials/builder/hyperv/common/CommonConfig-not-required.mdx
+++ b/docs-partials/builder/hyperv/common/CommonConfig-not-required.mdx
@@ -97,6 +97,8 @@
 
 - `keep_registered` (bool) - If "true", Packer will not delete the VM from
   The Hyper-V manager.
+  The resulting VM will be housed in a randomly generated folder under %TEMP% by default.
+  You can set the `temp_path` variable to change the location of the folder.
 
 - `skip_compaction` (bool) - If true skip compacting the hard disk for
   the virtual machine when exporting. This defaults to false.


### PR DESCRIPTION
After working on #115 (which fixed #7), a bug was discovered when using 2 mutually exclusives parameters: `skip_export` and `keep_registered`. This PR fixes this by ensuring both parameters are not set together and explaining it in the documentation.

This PR closes #121.
