### PR TITLE
fix: Do not attempt to modify SecureBootTemplate on a VM with a vTPM initialized

### DIFF
--- a/builder/hyperv/common/powershell/hyperv/hyperv.go
+++ b/builder/hyperv/common/powershell/hyperv/hyperv.go
@@ -718,8 +718,10 @@ func SetVirtualMachineSecureBoot(vmName string, enableSecureBoot bool, templateN
 	var script = `
 param([string]$vmName, [string]$enableSecureBootString, [string]$templateName)
 $cmdlet = Get-Command Hyper-V\Set-VMFirmware
+# We cannot modify SecureBoot Templates on VMs with a TPM enabled
+$tpmEnabled = Hyper-V\Get-VMSecurity -VMName $vmName | Select-Object -ExpandProperty TpmEnabled
 # The SecureBootTemplate parameter is only available in later versions
-if ($cmdlet.Parameters.SecureBootTemplate) {
+if ($cmdlet.Parameters.SecureBootTemplate -and !$tpmEnabled) {
 	Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBootString -SecureBootTemplate $templateName
 } else {
 	Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBootString

--- a/builder/hyperv/common/powershell/hyperv/hyperv.go
+++ b/builder/hyperv/common/powershell/hyperv/hyperv.go
@@ -633,6 +633,10 @@ param([string]$vmName)
 $generation = Hyper-V\Get-Vm -Name $vmName | %{$_.Generation}
 if (!$generation){
     $generation = 1
+} elseif ($generation.toString() -notmatch "\d"){
+	throw "Unable to parse VM generation. Are there multiple VMs with the same name?"
+} else {
+	return $generation
 }
 return $generation
 `
@@ -718,10 +722,14 @@ func SetVirtualMachineSecureBoot(vmName string, enableSecureBoot bool, templateN
 	var script = `
 param([string]$vmName, [string]$enableSecureBootString, [string]$templateName)
 $cmdlet = Get-Command Hyper-V\Set-VMFirmware
-# We cannot modify SecureBoot Templates on VMs with a TPM enabled
+
+# If the VM had a TPM initialized previously, we cannot modify the SecureBootTemplate setting
 $tpmEnabled = Hyper-V\Get-VMSecurity -VMName $vmName | Select-Object -ExpandProperty TpmEnabled
+# VMKeyProtector defaults to a 4-byte value if VM did not have a TPM initialized
+$keyProtector = Hyper-V\Get-VMKeyProtector -VMName $vmName
+
 # The SecureBootTemplate parameter is only available in later versions
-if ($cmdlet.Parameters.SecureBootTemplate -and !$tpmEnabled) {
+if ($cmdlet.Parameters.SecureBootTemplate -and !$tpmEnabled -and $keyProtector.Length -eq 4) {
 	Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBootString -SecureBootTemplate $templateName
 } else {
 	Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBootString
@@ -751,8 +759,18 @@ Hyper-V\Disable-VMTPM -VMName $vmName
 	if enableTPM {
 		script = `
 param([string]$vmName)
-Hyper-V\Set-VMKeyProtector -VMName $vmName -NewLocalKeyProtector
-Hyper-V\Enable-VMTPM -VMName $vmName
+$tpmEnabled = Hyper-V\Get-VMSecurity -VMName $vmName | Select-Object -ExpandProperty TpmEnabled
+# VMKeyProtector defaults to a 4-byte value if VM did not have a TPM initialized
+$keyProtector = Hyper-V\Get-VMKeyProtector -VMName $vmName
+
+if (!$tpmEnabled) {
+	if ($keyProtector.Length -eq 4) {
+	    # TPM not initialized, start fresh
+		Hyper-V\Set-VMKeyProtector -VMName $vmName -NewLocalKeyProtector
+	}
+
+	Hyper-V\Enable-VMTPM -VMName $vmName
+}
 `
 	}
 


### PR DESCRIPTION
When running the `hyperv-vmcx` builder, the plugin will always attempt to set the `-SecureBootTemplate` parameter if it is detected as available. However, when the source .vmcx template has a vTPM initialized (e.g. if it is a Windows 11 HyperV VM) then this operation will always fail:

```
2024-11-18T15:02:25-08:00: Build 'hyperv-vmcx' errored after 41 seconds 321 milliseconds: Error setting secure boot: PowerShell error: Hyper-V\Set-VMFirmware : 'win11_24H2-master-bdonaldson-TEST' failed to modify settings.
Cannot modify the secure boot template ID property.
'win11_24H2-master-bdonaldson-TEST' failed to modify settings. (Virtual machine ID
4DCCACA2-2DB5-465D-86E4-680373C80102)
Cannot modify the secure boot template ID property after the virtual TPM is initialized.
At C:\Users\bdonaldson\AppData\Local\Temp\2\Powershell1356268187.ps1:6 char:2
+     Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableS ...
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Set-VMFirmware], VirtualizationException
    + FullyQualifiedErrorId : OperationFailed,Microsoft.HyperV.PowerShell.Commands.SetVMFirmware
```

This change makes it so that Packer will only attempt to reconfigure the SecureBootTemplate if there is no initialized vTPM. If there is a vTPM, it will simply skip attempting to set the SecureBootTemplate, but continue to configure SecureBoot as desired. 

Closes #49 
