### PR TITLE
fix: Clearer error messaging when VM generation detection goes wrong

### DIFF
--- a/builder/hyperv/common/powershell/hyperv/hyperv.go
+++ b/builder/hyperv/common/powershell/hyperv/hyperv.go
@@ -633,6 +633,10 @@ param([string]$vmName)
 $generation = Hyper-V\Get-Vm -Name $vmName | %{$_.Generation}
 if (!$generation){
     $generation = 1
+} elseif ($generation.toString() -notmatch "\d"){
+	throw "Unable to parse VM generation. Are there multiple VMs with the name $vmName?"
+} else {
+	return $generation
 }
 return $generation
 `

--- a/builder/hyperv/common/powershell/powershell.go
+++ b/builder/hyperv/common/powershell/powershell.go
@@ -347,6 +347,10 @@ param([string]$vmName)
 $generation = Hyper-V\Get-Vm -Name $vmName | %{$_.Generation}
 if (!$generation){
     $generation = 1
+} elseif ($generation.toString() -notmatch "\d"){
+	throw "Unable to parse VM generation. Are there multiple VMs with the name $vmName?"
+} else {
+	return $generation
 }
 return $generation
 `


### PR DESCRIPTION
When running a Packer build in a situation where you already have a HyperV VM with the same name as your desired build VM's name, you will receive a cryptic error when Packer attempts to determine the VM's generation to determine its capabilities:

```
2024-11-18T15:03:35-08:00: Build 'hyperv-vmcx' errored after 55 seconds 702 milliseconds: Error detecting vm generation: strconv.ParseUint: parsing "2\r\n2": invalid syntax

==> Wait completed after 55 seconds 702 milliseconds

==> Some builds didn't complete successfully and had errors:
--> hyperv-vmcx: Error detecting vm generation: strconv.ParseUint: parsing "2\r\n2": invalid syntax
```

By adding a check to compare the result of the script that detects the generation of the VM to a regex, it does not alter the functionality, but makes it much clearer that the error happened because the VM generation detection script returned an unexpected result.

```
2024-11-18T15:29:54-08:00: Build 'hyperv-vmcx' errored after 1 minute 5 seconds: Error detecting vm generation: PowerShell error: Unable to parse VM generation. Are there multiple VMs with the same name?
```
I initially looked at swallowing the error if the results of the generation check were all identical (e.g. if you have 3 VMs and all are generation 2, logically you could return that your VM is generation 2,) but that opens the door to problems later when other commands run against a given VM name and receive multiple results (e.g. powering on all the VMs instead of just the one you wanted.) 

